### PR TITLE
Stop tracking model if 'destroy' triggered

### DIFF
--- a/backbone.uniquemodel.js
+++ b/backbone.uniquemodel.js
@@ -120,10 +120,10 @@
       if (this.storage) {
         if (instance.id)
           this.storage.save(instance.id, instance.attributes);
-
-        instance.on('sync', this.instanceSync, this);
-        instance.on('destroy', this.instanceDestroy, this);
       }
+
+      instance.on('sync', this.instanceSync, this);
+      instance.on('destroy', this.instanceDestroy, this);
 
       return instance;
     },
@@ -136,8 +136,14 @@
 
     // Event handler when 'destroy' is triggered on an instance
     instanceDestroy: function (instance) {
+      var id = instance.id;
       if (this.storage)
-        this.storage.remove(instance.id);
+        this.storage.remove(id);
+
+      // Stop tracking this model; otherwise mem leak (there are other
+      // sources of memory leaks we need to address, but hey, here's one)
+      if (this.instances[id])
+        delete this.instances[id];
     },
 
     // Event handler when 'sync' is triggered on the storage adapter

--- a/test/test.js
+++ b/test/test.js
@@ -68,6 +68,28 @@
     }));
   });
 
+  test('destroying intance removes from cache', function () {
+    var User = Backbone.Model.extend({});
+    var UniqueUser = Backbone.UniqueModel(User, 'DestroyTestUser');
+
+    var user = new UniqueUser({
+      id: 2,
+      name: 'Bobby Drake'
+    });
+
+    var modelCache = Backbone.UniqueModel.getModelCache('DestroyTestUser');
+    var model = modelCache.get({ id: 2});
+
+    equal(model, user);
+
+    model.trigger('destroy', model);
+
+    // Note that modelCache.get will create a new instance; so just verify
+    // new instance doesn't match old one
+    model = modelCache.get({ id: 2});
+    notEqual(model, user);
+  });
+
   module('localStorage', {
     setup: function () {
       var self = this;


### PR DESCRIPTION
Starting to tackle the issue where UniqueModel holds on to instance references indefinitely. This is just a small first step.
