### PR TITLE
Maintain uniques on models whose id is set later (fixes #13 & #15)  

### DIFF
--- a/backbone.uniquemodel.js
+++ b/backbone.uniquemodel.js
@@ -123,9 +123,12 @@
     newModel: function (attrs, options) {
       var instance = new this.Model(attrs, options);
 
-      if(!instance.id) {
-        instance.once('change:'+instance.idAttribute, function() {
-          if(!this.instances[instance.id]) this.instances[instance.id] = instance;
+      if (!instance.id) {
+        // If this model currently has no id, but gains one later (e.g. via sync),
+        // then add it to the list of tracked instances
+        instance.once('change:' + instance.idAttribute, function () {
+          if (!this.instances[instance.id])
+            this.instances[instance.id] = instance;
         }, this);
       }
 

--- a/backbone.uniquemodel.js
+++ b/backbone.uniquemodel.js
@@ -123,6 +123,12 @@
     newModel: function (attrs, options) {
       var instance = new this.Model(attrs, options);
 
+      if(!instance.id) {
+        instance.once('change:'+instance.idAttribute, function() {
+          if(!this.instances[instance.id]) this.instances[instance.id] = instance;
+        }, this);
+      }
+
       if (this.storage) {
         if (instance.id)
           this.storage.save(instance.id, instance.attributes);

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,17 @@
     equal(UniqueUser.someStaticAttribute, 'test');
   });
 
+  test("uniques are maintained also when the ID is set retroactively", function () {
+    var User = Backbone.Model.extend({});
+    var UniqueUser = Backbone.UniqueModel(User);
+
+    var newUser = new UniqueUser({name: 'John Doe'});
+    newUser.set("id", 9);
+
+    var sameUser = new UniqueUser({id: 9});
+    equal(newUser, sameUser);
+  });
+
   test('collection maintains uniques', function () {
     var User = Backbone.Model.extend({});
     var UniqueUser = Backbone.UniqueModel(User);


### PR DESCRIPTION
Same PR as https://github.com/disqus/backbone.uniquemodel/pull/15 but it's ready to merge.
