### PR TITLE
Fix null property access when storage is cleared

### DIFF
--- a/backbone.uniquemodel.js
+++ b/backbone.uniquemodel.js
@@ -264,7 +264,7 @@
       '(.+)'                         // key
     ].join('\\' + UniqueModel.STORAGE_KEY_DELIMETER));
 
-    var match = key.match(re);
+    var match = key && key.match(re);
     if (!match)
       return;
 


### PR DESCRIPTION
When `localStorage` or `sessionStorage` are cleared from another window / iframe, the `storage` event fires with `key: null`.